### PR TITLE
2.0 Enable split build and source directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,17 @@ allprojects {
     repositories {
         jcenter()
     }
+
+    // Setup the project build directories relative to a base build
+    // directory if one is defined in, for example, a Gradle
+    // properties file.  Note that this is a "poor man's" solution and
+    // does not preserve project hierarchies.
+    //
+    // TODO: A better solution, possibly optimal, would be to provide
+    // a Gradle plugin to handle a more complete implementation.
+    if (baseBuildDir != null) {
+        buildDir = baseBuildDir + (parent == null ? "/${project.name}/build" : "/${rootProject.name}/${project.name}/build")
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
If one is defined, use a base directory to place the build artifacts for
all project modules thus allowing the project source files and build
files to be in separate directories and possbily separate file systems,
in case that matters.  This is particularly well suited to using Google
Drive as a backup for work not yet pushed up to GitHub and to facilitate
the use of multiple development systems.
